### PR TITLE
Add Colors extension and improve jiripolasek metadata

### DIFF
--- a/extensions/jiripolasek/colors/extension.json
+++ b/extensions/jiripolasek/colors/extension.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../../../.github/schemas/extension.schema.json",
+  "id": "jiripolasek.colors",
+  "title": "Colors for Command Palette",
+  "shortDescription": "Visualize, convert, and manipulate colors instantly from Command Palette.",
+  "description": "Instant color visualization, conversion, and manipulation directly within the Command Palette. Effortlessly preview, transform, and work with colors—no need to leave your workflow.\n\nConvert between color formats including HEX, RGB, HSL, and more. Preview colors in real time as you type, pick colors from the screen, and copy values in your preferred format.\n\nPerfect for designers and developers who need quick access to color tools without switching applications.",
+  "author": {
+    "name": "Jiri Polasek",
+    "url": "https://github.com/jiripolasek"
+  },
+  "icon": "icon.svg",
+  "homepage": "https://github.com/jiripolasek/ColorsExtension",
+  "tags": [
+    "colors",
+    "hex",
+    "rgb",
+    "design"
+  ],
+  "categories": [
+    "developer-tools",
+    "utilities-and-tools"
+  ],
+  "installSources": [
+    {
+      "type": "msstore",
+      "id": "9NDDQK5VVLNB"
+    },
+    {
+      "type": "winget",
+      "id": "JiriPolasek.ColorsforCommandPalette"
+    }
+  ]
+}

--- a/extensions/jiripolasek/colors/icon.svg
+++ b/extensions/jiripolasek/colors/icon.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g>
+        <g transform="matrix(51.2,0,0,51.2,0,0)">
+            <circle cx="10" cy="10" r="10" style="fill:none;"/>
+            <clipPath id="_clip1">
+                <circle cx="10" cy="10" r="10"/>
+            </clipPath>
+            <g clip-path="url(#_clip1)">
+                <path d="M0,0L10,10L0,10L0,0Z" style="fill:url(#_Linear2);"/>
+                <g transform="matrix(-1,-1.22465e-16,1.22465e-16,-1,10,10)">
+                    <path d="M0,0L10,10L0,10L0,0Z" style="fill:url(#_Linear3);"/>
+                </g>
+                <g transform="matrix(1,0,0,1,10,10)">
+                    <path d="M0,0L10,10L0,10L0,0Z" style="fill:url(#_Linear4);"/>
+                </g>
+                <g transform="matrix(-1,-1.22465e-16,1.22465e-16,-1,20,20)">
+                    <path d="M0,0L10,10L0,10L0,0Z" style="fill:url(#_Linear5);"/>
+                </g>
+                <g transform="matrix(6.12323e-17,-1,1,6.12323e-17,10,10)">
+                    <path d="M0,0L10,10L0,10L0,0Z" style="fill:url(#_Linear6);"/>
+                </g>
+                <g transform="matrix(-1.83697e-16,1,-1,-1.83697e-16,20,1.77636e-15)">
+                    <path d="M0,0L10,10L0,10L0,0Z" style="fill:rgb(65,132,228);"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,10,10)">
+                    <path d="M0,0L10,10L0,10L0,0Z" style="fill:url(#_Linear7);"/>
+                </g>
+                <g transform="matrix(1,-1.22465e-16,-1.22465e-16,-1,1.77636e-15,20)">
+                    <path d="M0,0L10,10L0,10L0,0Z" style="fill:rgb(255,204,37);"/>
+                </g>
+            </g>
+        </g>
+        <g transform="matrix(166.374,0,0,166.374,-1155.31,-1155.31)">
+            <circle cx="10.031" cy="10.031" r="1.969" style="fill:url(#_Radial8);"/>
+        </g>
+        <g transform="matrix(166.374,0,0,166.374,-1155.31,-1155.31)">
+            <circle cx="10.031" cy="10.031" r="1.969" style="fill:url(#_Radial9);"/>
+        </g>
+        <g transform="matrix(16.8815,-4.91983,4.91983,16.8815,251.993,378.87)">
+            <path d="M3.839,5.858C6.779,1.942 12.869,0.803 17.203,3.498C21.483,6.158 23.057,11.275 21.303,16.075C19.648,20.608 15.287,22.403 12.144,20.123C10.967,19.269 10.51,18.198 10.29,16.459L10.184,15.472L10.139,15.074C10.016,14.14 9.828,13.722 9.434,13.502C8.899,13.204 8.542,13.197 7.839,13.469L7.488,13.615L7.309,13.693C6.295,14.133 5.621,14.288 4.768,14.109L4.568,14.062L4.404,14.015C1.615,13.151 1.202,9.368 3.839,5.858ZM16.767,10.58C16.913,11.125 17.41,11.507 17.975,11.507C18.66,11.507 19.225,10.942 19.225,10.257C19.225,10.147 19.21,10.039 19.182,9.933C19.036,9.388 18.539,9.006 17.975,9.006C17.289,9.006 16.724,9.571 16.724,10.256C16.724,10.366 16.739,10.474 16.767,10.58ZM17.262,14.068C17.397,14.628 17.902,15.025 18.477,15.025C19.163,15.025 19.727,14.461 19.727,13.775C19.727,13.655 19.71,13.536 19.676,13.421C19.52,12.891 19.03,12.525 18.477,12.525C17.791,12.525 17.227,13.089 17.227,13.775C17.227,13.874 17.239,13.972 17.262,14.068ZM14.788,7.577C14.934,8.122 15.431,8.504 15.996,8.504C16.681,8.504 17.246,7.939 17.246,7.254C17.246,7.144 17.231,7.036 17.203,6.93C17.057,6.385 16.56,6.003 15.996,6.003C15.31,6.003 14.745,6.568 14.745,7.254C14.745,7.363 14.76,7.471 14.788,7.577ZM14.76,16.575C14.906,17.12 15.403,17.502 15.968,17.502C16.653,17.502 17.218,16.937 17.218,16.252C17.218,16.142 17.203,16.034 17.175,15.928C17.029,15.383 16.532,15.001 15.968,15.001C15.282,15.001 14.717,15.566 14.717,16.252C14.717,16.361 14.732,16.469 14.76,16.575ZM11.263,6.605C11.405,7.155 11.905,7.542 12.473,7.542C13.159,7.542 13.723,6.978 13.723,6.292C13.723,6.18 13.708,6.068 13.678,5.959C13.529,5.419 13.034,5.042 12.473,5.042C11.788,5.042 11.223,5.607 11.223,6.292C11.223,6.398 11.237,6.503 11.263,6.605Z" style="fill:url(#_Radial10);fill-rule:nonzero;"/>
+        </g>
+    </g>
+    <g transform="matrix(16.8815,-4.91983,4.91983,16.8815,251.993,378.87)">
+        <path d="M3.839,5.858C6.779,1.942 12.869,0.803 17.203,3.498C21.483,6.158 23.057,11.275 21.303,16.075C19.648,20.608 15.287,22.403 12.144,20.123C10.967,19.269 10.51,18.198 10.29,16.459L10.184,15.472L10.139,15.074C10.016,14.14 9.828,13.722 9.434,13.502C8.899,13.204 8.542,13.197 7.839,13.469L7.488,13.615L7.309,13.693C6.295,14.133 5.621,14.288 4.768,14.109L4.568,14.062L4.404,14.015C1.615,13.151 1.202,9.368 3.839,5.858ZM16.767,10.58C16.913,11.125 17.41,11.507 17.975,11.507C18.66,11.507 19.225,10.942 19.225,10.257C19.225,10.147 19.21,10.039 19.182,9.933C19.036,9.388 18.539,9.006 17.975,9.006C17.289,9.006 16.724,9.571 16.724,10.256C16.724,10.366 16.739,10.474 16.767,10.58ZM17.262,14.068C17.397,14.628 17.902,15.025 18.477,15.025C19.163,15.025 19.727,14.461 19.727,13.775C19.727,13.655 19.71,13.536 19.676,13.421C19.52,12.891 19.03,12.525 18.477,12.525C17.791,12.525 17.227,13.089 17.227,13.775C17.227,13.874 17.239,13.972 17.262,14.068ZM14.788,7.577C14.934,8.122 15.431,8.504 15.996,8.504C16.681,8.504 17.246,7.939 17.246,7.254C17.246,7.144 17.231,7.036 17.203,6.93C17.057,6.385 16.56,6.003 15.996,6.003C15.31,6.003 14.745,6.568 14.745,7.254C14.745,7.363 14.76,7.471 14.788,7.577ZM14.76,16.575C14.906,17.12 15.403,17.502 15.968,17.502C16.653,17.502 17.218,16.937 17.218,16.252C17.218,16.142 17.203,16.034 17.175,15.928C17.029,15.383 16.532,15.001 15.968,15.001C15.282,15.001 14.717,15.566 14.717,16.252C14.717,16.361 14.732,16.469 14.76,16.575ZM11.263,6.605C11.405,7.155 11.905,7.542 12.473,7.542C13.159,7.542 13.723,6.978 13.723,6.292C13.723,6.18 13.708,6.068 13.678,5.959C13.529,5.419 13.034,5.042 12.473,5.042C11.788,5.042 11.223,5.607 11.223,6.292C11.223,6.398 11.237,6.503 11.263,6.605Z" style="fill:url(#_Radial11);fill-rule:nonzero;"/>
+    </g>
+    <defs>
+        <linearGradient id="_Linear2" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(10.031,9,-9,10.031,1.77636e-15,3)"><stop offset="0" style="stop-color:rgb(112,219,82);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(38,120,15);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear3" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-7.15191,-12.1519,12.1519,-7.15191,5,10)"><stop offset="0" style="stop-color:rgb(126,219,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(0,164,227);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear4" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(4.96899,7.03101,-7.03101,4.96899,0.0310053,-0.0310053)"><stop offset="0" style="stop-color:rgb(229,60,60);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(180,0,0);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear5" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-28,-19,19,-28,6,9)"><stop offset="0" style="stop-color:rgb(208,0,119);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(115,0,66);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear6" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-13,12,-12,-13,5,5)"><stop offset="0" style="stop-color:rgb(117,0,201);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(54,0,93);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear7" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-13,12,12,13,6,1)"><stop offset="0" style="stop-color:rgb(255,127,1);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(154,76,0);stop-opacity:1"/></linearGradient>
+        <radialGradient id="_Radial8" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(3.36101,3.36101,-3.36101,3.36101,8.63899,8.63899)"><stop offset="0" style="stop-color:white;stop-opacity:1"/><stop offset="1" style="stop-color:rgb(179,179,179);stop-opacity:1"/></radialGradient>
+        <radialGradient id="_Radial9" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(3.36101,3.36101,-3.36101,3.36101,8.63899,8.63899)"><stop offset="0" style="stop-color:white;stop-opacity:1"/><stop offset="1" style="stop-color:rgb(179,179,179);stop-opacity:1"/></radialGradient>
+        <radialGradient id="_Radial10" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(8.12614,23.338,-23.338,8.12614,9.05338,-4.63995)"><stop offset="0" style="stop-color:rgb(131,131,131);stop-opacity:1"/><stop offset="0.46" style="stop-color:rgb(55,55,55);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(34,34,34);stop-opacity:1"/></radialGradient>
+        <radialGradient id="_Radial11" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(8.12614,23.338,-23.338,8.12614,9.05338,-4.63995)"><stop offset="0" style="stop-color:rgb(131,131,131);stop-opacity:1"/><stop offset="0.46" style="stop-color:rgb(55,55,55);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(34,34,34);stop-opacity:1"/></radialGradient>
+    </defs>
+</svg>

--- a/extensions/jiripolasek/errors-and-codes/extension.json
+++ b/extensions/jiripolasek/errors-and-codes/extension.json
@@ -17,7 +17,8 @@
     "windows"
   ],
   "categories": [
-    "developer-tools"
+    "developer-tools",
+    "utilities-and-tools"
   ],
   "installSources": [
     {

--- a/extensions/jiripolasek/symbols-and-emojis/extension.json
+++ b/extensions/jiripolasek/symbols-and-emojis/extension.json
@@ -3,10 +3,10 @@
   "id": "jiripolasek.symbols-and-emojis",
   "title": "Symbols and Emojis for Command Palette",
   "shortDescription": "Search and insert Unicode symbols, emojis, and special characters with code points and details.",
-  "description": "Search and insert Unicode symbols, emojis, and special characters directly from the Command Palette. Browse or search through a comprehensive library of characters with their code points and details.\n\nQuickly find the exact symbol you need—whether it’s a mathematical operator, currency sign, arrow, emoji, or any other Unicode character—and insert it into your workflow with a single action.",
+  "description": "Need to quickly find and use a symbol, emoji, or special character? This extension brings a full Unicode character explorer right into your Command Palette. Instantly search for any emoji, symbol, or Unicode character by name or category, view detailed character info, and copy it to your clipboard with a click.\n\nWhether you're a developer, designer, or power user, this tool saves time by providing code points, escape sequences, HTML entities, and LaTeX representations all in one place. No need to open a separate app or website\u2014everything is accessible right from your workspace.\n\nPerfect for coding, writing documentation, creating content, or simply spicing up your messages with emojis.",
   "author": {
-    "url": "https://github.com/jiripolasek",
-    "name": "Jiri Polasek"
+    "name": "Jiri Polasek",
+    "url": "https://github.com/jiripolasek"
   },
   "icon": "icon.png",
   "homepage": "https://apps.microsoft.com/detail/9NZ06M9CNV77",
@@ -22,8 +22,8 @@
   ],
   "installSources": [
     {
-      "id": "9NZ06M9CNV77",
-      "type": "msstore"
+      "type": "msstore",
+      "id": "9NZ06M9CNV77"
     }
   ]
 }

--- a/extensions/jiripolasek/toggle-dark-mode/extension.json
+++ b/extensions/jiripolasek/toggle-dark-mode/extension.json
@@ -5,8 +5,8 @@
   "shortDescription": "Quickly toggle Windows or application dark mode directly from Command Palette.",
   "description": "Toggle dark mode quickly from Command Palette. Switch between light and dark color modes for Windows or individual applications with a single command.\n\nSet color mode for the system and applications together or separately, and configure the default behavior to suit your needs. Perfect for quickly adapting your display to different lighting conditions or personal preferences.",
   "author": {
-    "url": "https://github.com/jiripolasek",
-    "name": "Jiri Polasek"
+    "name": "Jiri Polasek",
+    "url": "https://github.com/jiripolasek"
   },
   "icon": "icon.png",
   "homepage": "https://github.com/jiripolasek/ToggleDarkModeExtension",
@@ -21,8 +21,8 @@
   ],
   "installSources": [
     {
-      "id": "9MZSV48WJM71",
-      "type": "msstore"
+      "type": "msstore",
+      "id": "9MZSV48WJM71"
     }
   ]
 }

--- a/extensions/jiripolasek/unit-converter/extension.json
+++ b/extensions/jiripolasek/unit-converter/extension.json
@@ -3,10 +3,10 @@
   "id": "jiripolasek.unit-converter",
   "title": "Unit Converter for Command Palette",
   "shortDescription": "Convert between common units of measurement like length, weight, time, volume, and area.",
-  "description": "Convert between common units of measurement directly from the Command Palette. Supports a wide range of unit categories including length, weight, time, volume, area, temperature, speed, and more.\n\nSimply type a value and unit to see instant conversions across all related units. Fast, accurate, and always accessible without leaving your workflow.",
+  "description": "Stop switching between apps or browsing the web for simple conversions. With Unit Converter for Command Palette, you can instantly convert between common units of measurement—right within your workflow.\n\nEasily convert between length, weight, time, volume, area, temperature, speed, and more without interrupting your flow. Simply open the Command Palette, type your query (like \"10 km in miles\"), and get results in real-time.\n\nWhether you're a developer, student, or multitasker, this extension helps you stay focused by delivering fast and accurate unit conversions. Perfect for anyone needing quick conversions without clutter or distraction.",
   "author": {
-    "url": "https://github.com/jiripolasek",
-    "name": "Jiri Polasek"
+    "name": "Jiri Polasek",
+    "url": "https://github.com/jiripolasek"
   },
   "icon": "icon.png",
   "homepage": "https://apps.microsoft.com/detail/9N46RM40VR8D",
@@ -21,8 +21,8 @@
   ],
   "installSources": [
     {
-      "id": "9N46RM40VR8D",
-      "type": "msstore"
+      "type": "msstore",
+      "id": "9N46RM40VR8D"
     }
   ]
 }


### PR DESCRIPTION
## Summary

### New extension
- **Colors for Command Palette** (JiriPolasek.ColorsforCommandPalette) - visualize, convert, and manipulate colors

### Metadata improvements (existing extensions)

| Extension | Change |
|-----------|--------|
| **symbols-and-emojis** | Enriched description with Microsoft Store content (392 to 693 chars); fixed field ordering |
| **unit-converter** | Enriched description with Microsoft Store content (347 to 645 chars); fixed field ordering |
| **toggle-dark-mode** | Fixed author/installSources field ordering for consistency |
| **errors-and-codes** | Added utilities-and-tools category |

All changes are cosmetic improvements to field ordering (name before url, type before id) and richer descriptions sourced from the Microsoft Store listings.