### PR TITLE
Remove PR comment step from validation workflow

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   validate:
@@ -28,8 +27,6 @@ jobs:
         run: pip install -r .github/scripts/requirements.txt
 
       - name: Validate extension submission
-        id: validate
-        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -39,42 +36,3 @@ jobs:
           else
             echo "No extension files changed."
           fi
-
-      - name: Comment on PR
-        if: always() && steps.validate.outcome != 'skipped'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            if (!fs.existsSync('validation-summary.md')) return;
-
-            const summary = fs.readFileSync('validation-summary.md', 'utf8');
-            const marker = '<!-- cmdpal-extension-validation -->';
-            const body = marker + '\n' + summary;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body?.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
-
-      - name: Fail if validation had errors
-        if: steps.validate.outcome == 'failure'
-        run: exit 1


### PR DESCRIPTION
## Problem

The **Comment on PR** step in \alidate-pr.yml\ fails on fork PRs with:

\\\
HttpError: Resource not accessible by integration (403)
\\\

This happens because \GITHUB_TOKEN\ for \pull_request\ events from forks is **read-only** — GitHub enforces this regardless of the \permissions\ block in the workflow.

## Fix

Remove the comment step entirely. Validation results are already written to \GITHUB_STEP_SUMMARY\ and are visible in the Actions UI.

**Changes:**
- Remove the \Comment on PR\ step
- Drop \pull-requests: write\ permission (no longer needed)
- Simplify the validate step (remove \id\/\continue-on-error\ since it's now the final step)