### PR TITLE
Add Microsoft Store install source to nickknissen.tailscale-command-palette

### DIFF
--- a/extensions/nickknissen/tailscale-command-palette/extension.json
+++ b/extensions/nickknissen/tailscale-command-palette/extension.json
@@ -23,6 +23,10 @@
   ],
   "installSources": [
     {
+      "type": "msstore",
+      "id": "9N5NWRQ9FBLM"
+    },
+    {
       "type": "winget",
       "id": "nickknissen.TailscaleCommandPalette"
     },


### PR DESCRIPTION
## Extension Submission

Updates the existing `nickknissen.tailscale-command-palette` entry — the extension is now published to the Microsoft Store, so this PR adds an `msstore` install source alongside the existing `winget` and `url` sources.

- Store listing: https://apps.microsoft.com/detail/9N5NWRQ9FBLM
- Repo: https://github.com/nickknissen/TailscaleCommandPalette

### Checklist

- [x] My folder follows the `<author>/<extension-name>` convention (lowercase, alphanumeric + hyphens only)
- [x] I have added an `extension.json` with all required fields
- [x] The `id` field in my `extension.json` matches my folder path (`author.extension-name`)
- [x] I have added an icon file (PNG or JPG, under 100 KB)
- [x] The `icon` field in `extension.json` matches my icon filename
- [x] My extension is available at the install source I specified (winget/MS Store/URL)
- [x] I have read the [Contributing Guide](../docs/CONTRIBUTING.md)

### Additional context

No icon, screenshots, or metadata changes — just the new `msstore` install source.