### PR TITLE
Updating for future npm install source

### DIFF
--- a/.github/schemas/extension.schema.json
+++ b/.github/schemas/extension.schema.json
@@ -133,6 +133,14 @@
             },
             "required": ["type", "id"],
             "additionalProperties": false
+          },
+          {
+            "properties": {
+              "type": { "const": "npm" },
+              "id": { "type": "string", "description": "NPM package name.", "minLength": 1, "examples": ["cooldev/weather-extension", "@org/extension"] }
+            },
+            "required": ["type", "id"],
+            "additionalProperties": false
           }
         ]
       }

--- a/.github/schemas/gallery.schema.json
+++ b/.github/schemas/gallery.schema.json
@@ -146,6 +146,14 @@
                 },
                 "required": ["type", "id"],
                 "additionalProperties": false
+              },
+              {
+                "properties": {
+                  "type": { "const": "npm" },
+                  "id": { "type": "string", "description": "NPM package name.", "minLength": 1 }
+                },
+                "required": ["type", "id"],
+                "additionalProperties": false
               }
             ]
           }


### PR DESCRIPTION
This pull request updates the JSON schema definitions for extensions and gallery items to support referencing NPM packages. The main change is the addition of a new object type for NPM packages, allowing them to be specified by their package name and type.

Schema updates for NPM package support:

* Added a new object type with `"type": "npm"` and an `"id"` field for NPM package names to the `extension.schema.json` file, enabling extensions to reference NPM packages.
* Added a similar object type with `"type": "npm"` and an `"id"` field for NPM package names to the `gallery.schema.json` file, allowing gallery items to reference NPM packages.

>[!NOTE]
> Still to do: Update generation scripts to validate npm package.
