### PR TITLE
Add homepage URL to extension.json

### DIFF
--- a/extensions/denniezorg/game-library-dock/extension.json
+++ b/extensions/denniezorg/game-library-dock/extension.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/ScymicX"
   },
   "icon": "icon.png",
+  "homepage": "https://github.com/ScymicX/Steam-Dock-Extension",
   "tags": [
     "gaming",
     "friends",


### PR DESCRIPTION
Due to a crash when opening the extension from the gallery:

[18:12:45.4391623] [Error] GlobalErrorHandler.cs::HandleException::69 System.ArgumentException: De parameter is onjuist.
   at ExtensionGalleryItemPage_obj1_Bindings.Update_ViewModel_Homepage(String, Int32)

Fix: adding missing `homepage` field to extension.json causes CmdPal to crash 
when opening the Game Library Dock entry in the gallery.

**Root cause:**
`ExtensionGalleryItemPage` binds `Homepage` to a UI element that expects a 
non-null string. The missing field causes an `ArgumentException` on page load.

**Fix:**
Added `"homepage": "https://github.com/ScymicX/Steam-Dock-Extension"` to 
`extensions/denniezorg/game-library-dock/extension.json`.