### PR TITLE
chore: regenerate extensions.json

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/CmdPal-Extensions/main/.github/schemas/gallery.schema.json",
   "version": "1.0",
-  "generatedAt": "2026-06-23T13:31:50Z",
+  "generatedAt": "2026-06-25T16:04:11Z",
   "extensionCount": 63,
   "extensions": [
     {
@@ -448,6 +448,7 @@
         "name": "DennieZorg",
         "url": "https://github.com/ScymicX"
       },
+      "homepage": "https://github.com/ScymicX/Steam-Dock-Extension",
       "tags": [
         "gaming",
         "friends",


### PR DESCRIPTION
Manual regeneration of `extensions.json` from the extension manifests under `extensions/` (via `.github/scripts/generate.py`).

This picks up content that was out of sync, e.g. an added `homepage` for the Steam Dock extension, and refreshes `generatedAt`.

Done ahead of the scheduled **Regenerate Gallery** workflow being wired up.