### PR TITLE
chore: add CODEOWNERS for extension submissions and automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Code owners for CmdPal-Extensions.
+#
+# Each line is a file pattern followed by one or more owners. The last
+# matching pattern for a changed file takes precedence. Owners listed here
+# are automatically requested for review, and the branch protection ruleset
+# requires a code-owner approval before such changes can merge.
+#
+# NOTE: The generated gallery file at the repo root, extensions.json, is
+# intentionally NOT assigned an owner. This lets the scheduled "Regenerate
+# Gallery" workflow update it automatically without a human code-owner review.
+# Contributor-authored content under /extensions/ IS owned below, so extension
+# submissions still require a moderator's approval.
+
+# Extension submissions from contributors.
+/extensions/ @michaeljolley @zadjii-msft @chatasweetie @crutkas @dhowett
+
+# Repository automation: workflows, generation/validation scripts, schemas,
+# and this CODEOWNERS file itself.
+/.github/ @michaeljolley @zadjii-msft @chatasweetie @crutkas @dhowett

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,14 +5,16 @@
 # are automatically requested for review, and the branch protection ruleset
 # requires a code-owner approval before such changes can merge.
 #
-# NOTE: The generated gallery file at the repo root, extensions.json, is
-# intentionally NOT assigned an owner. This lets the scheduled "Regenerate
-# Gallery" workflow update it automatically without a human code-owner review.
-# Contributor-authored content under /extensions/ IS owned below, so extension
-# submissions still require a moderator's approval.
+# The generated gallery file (extensions.json) is owned as well: the
+# regeneration automation opens a PR authored by a maintainer, and a
+# DIFFERENT code owner must review it before it merges (the author cannot
+# approve their own PR).
 
 # Extension submissions from contributors.
 /extensions/ @niels9001 @michaeljolley @zadjii-msft @chatasweetie @crutkas @dhowett
+
+# Generated gallery file, produced by .github/scripts/generate.py.
+/extensions.json @niels9001 @michaeljolley @zadjii-msft @chatasweetie @crutkas @dhowett
 
 # Repository automation: workflows, generation/validation scripts, schemas,
 # and this CODEOWNERS file itself.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,8 @@
 # submissions still require a moderator's approval.
 
 # Extension submissions from contributors.
-/extensions/ @michaeljolley @zadjii-msft @chatasweetie @crutkas @dhowett
+/extensions/ @niels9001 @michaeljolley @zadjii-msft @chatasweetie @crutkas @dhowett
 
 # Repository automation: workflows, generation/validation scripts, schemas,
 # and this CODEOWNERS file itself.
-/.github/ @michaeljolley @zadjii-msft @chatasweetie @crutkas @dhowett
+/.github/ @niels9001 @michaeljolley @zadjii-msft @chatasweetie @crutkas @dhowett


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so extension submissions and repo automation get the right required reviewers.

## Ownership
| Path | Owners | Why |
|---|---|---|
| `/extensions/` | moderators | Contributor submissions require a moderator (code-owner) review |
| `/.github/` | moderators | Workflows, scripts, schemas, and CODEOWNERS itself |
| root `extensions.json` | *(intentionally unowned)* | Lets the scheduled Regenerate Gallery automation update it without a human review |

This also activates the existing `require_code_owner_review` branch-protection rule, which was a no-op until now (no CODEOWNERS existed).

## Notes
- Listed as **individual usernames** for now: @michaeljolley, @zadjii-msft, @chatasweetie, @crutkas, @dhowett. Once a team exists, we can swap these for a single `@microsoft/<team>` handle.
- Deliberately **no catch-all (`*`) rule**, so the generated `extensions.json` stays unowned and the automation remains hands-off.