### PR TITLE
Adding support for NPM as an extension source

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Please fill out the checklist below to help us review your PR quickly.
 - [ ] The `id` field in my `extension.json` matches my folder path (`author.extension-name`)
 - [ ] I have added an icon file (PNG or JPG, under 100 KB)
 - [ ] The `icon` field in `extension.json` matches my icon filename
-- [ ] My extension is available at the install source I specified (winget/MS Store)
+- [ ] My extension is available at the install source I specified (winget/MS Store/npm)
 - [ ] I have read the [Contributing Guide](../docs/CONTRIBUTING.md)
 
 ### Additional context

--- a/.github/schemas/extension.schema.json
+++ b/.github/schemas/extension.schema.json
@@ -133,6 +133,14 @@
             },
             "required": ["type", "id"],
             "additionalProperties": false
+          },
+          {
+            "properties": {
+              "type": { "const": "npm" },
+                "id": { "type": "string", "description": "NPM package identifier", "minLength": 1, "examples": ["@baldbeardedbuilder/gif-search"] }
+            },
+            "required": ["type", "id"],
+            "additionalProperties": false
           }
         ]
       }

--- a/.github/schemas/gallery.schema.json
+++ b/.github/schemas/gallery.schema.json
@@ -146,6 +146,14 @@
                 },
                 "required": ["type", "id"],
                 "additionalProperties": false
+              },
+              {
+                "properties": {
+                  "type": { "const": "npm" },
+                  "id": { "type": "string", "description": "NPM package identifier", "minLength": 1 }
+                },
+                "required": ["type", "id"],
+                "additionalProperties": false
               }
             ]
           }

--- a/.github/scripts/validate.py
+++ b/.github/scripts/validate.py
@@ -29,6 +29,7 @@ import re
 import subprocess
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import List, Set
 
@@ -82,6 +83,9 @@ WINGET_PKGS_API_URL = (
 )
 WINGET_PKGS_RAW_URL = (
     "https://raw.githubusercontent.com/microsoft/winget-pkgs/master/manifests"
+)
+NPM_PKGS_URL = (
+    "https://registry.npmjs.org/"
 )
 NETWORK_TIMEOUT = 15
 
@@ -380,6 +384,59 @@ def validate_winget_source(
     return errors, warnings
 
 
+def validate_npm_source(
+    package_id: str, extension_title: str, display_path: str
+) -> tuple[List[str], List[str]]:
+    """Validate an npm install source package name against the npm registry.
+
+    Returns (errors, warnings).
+    """
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    # Scoped packages (e.g. "@scope/name") must have the slash percent-encoded
+    # in the URL, but the leading "@" must remain unencoded.
+    encoded_id = urllib.parse.quote(package_id, safe="@")
+    url = f"{NPM_PKGS_URL}{encoded_id}"
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "CmdPal-Extensions-Validator/1.0"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=NETWORK_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            errors.append(
+                f"{display_path}: npm package \"{package_id}\" was not found. "
+                f"Verify the package name is correct at "
+                f"https://www.npmjs.com/package/{package_id}"
+            )
+        else:
+            warnings.append(
+                f"{display_path}: Could not reach npm registry to validate "
+                f"\"{package_id}\" (HTTP {exc.code}). Skipping online validation."
+            )
+        return errors, warnings
+    except (urllib.error.URLError, OSError):
+        warnings.append(
+            f"{display_path}: Could not reach npm registry to validate "
+            f"\"{package_id}\". Skipping online validation."
+        )
+        return errors, warnings
+
+    # The registry "name" field is the canonical package name; compare it to
+    # the extension title as a loose sanity check.
+    registry_name = data.get("name", "")
+    if registry_name and registry_name.strip().lower() != extension_title.strip().lower():
+        warnings.append(
+            f"{display_path}: npm package name mismatch — "
+            f"npm has \"{registry_name}\" but extension.json title is "
+            f"\"{extension_title}\""
+        )
+
+    return errors, warnings
+
+
 # ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
@@ -550,6 +607,12 @@ def validate_extension(folder: pathlib.Path, schema: dict, id_index: dict[str, p
                 warnings.extend(src_warnings)
             elif source_type == "winget" and source_id:
                 src_errors, src_warnings = validate_winget_source(
+                    source_id, extension_title, display_path
+                )
+                errors.extend(src_errors)
+                warnings.extend(src_warnings)
+            elif source_type == "npm" and source_id:
+                src_errors, src_warnings = validate_npm_source(
                     source_id, extension_title, display_path
                 )
                 errors.extend(src_errors)


### PR DESCRIPTION
This pull request adds support for validating npm packages as extension install sources. The changes update the schema definitions to allow specifying npm packages, update documentation accordingly, and enhance the validation script to check npm package existence and provide helpful warnings.

**Schema and documentation updates:**

* `.github/schemas/extension.schema.json` and `.github/schemas/gallery.schema.json`: Added support for specifying npm packages as valid install sources by allowing `"type": "npm"` with an `id` field. [[1]](diffhunk://#diff-4e61249358082fe6a32948d1a31210256229773dc635371b40e13d95dc8c842eR136-R143) [[2]](diffhunk://#diff-0304ebb6bb4f17e7fc6c799418e35746c1c80ff23f5009d2784334ca646c1283R149-R156)
* [`.github/PULL_REQUEST_TEMPLATE.md`](diffhunk://#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35L13-R13): Updated checklist to mention npm as a valid install source.

**Validation script enhancements:**

* [`.github/scripts/validate.py`](diffhunk://#diff-e5684cf6d80ca3f2510b1494039411dec2a56b19f49d1256b541bea2289fe9f9R387-R439): Added `validate_npm_source` function to check npm package existence via the npm registry, including proper URL encoding for scoped packages. It also warns if the package name does not match the extension title.
* [`.github/scripts/validate.py`](diffhunk://#diff-e5684cf6d80ca3f2510b1494039411dec2a56b19f49d1256b541bea2289fe9f9R614-R619): Integrated npm validation into the main validation flow for extensions specifying an npm source.
* [`.github/scripts/validate.py`](diffhunk://#diff-e5684cf6d80ca3f2510b1494039411dec2a56b19f49d1256b541bea2289fe9f9R32): Added necessary imports and constants for npm registry access. [[1]](diffhunk://#diff-e5684cf6d80ca3f2510b1494039411dec2a56b19f49d1256b541bea2289fe9f9R32) [[2]](diffhunk://#diff-e5684cf6d80ca3f2510b1494039411dec2a56b19f49d1256b541bea2289fe9f9R87-R89)
