### PR TITLE
Point Quick Shell gallery WinGet at CmdPal-only package

### DIFF
--- a/extensions/tonythethompson/quickshell/extension.json
+++ b/extensions/tonythethompson/quickshell/extension.json
@@ -29,7 +29,7 @@
     },
     {
       "type": "winget",
-      "id": "tonythethompson.QuickShell"
+      "id": "tonythethompson.QuickShellforCmdPal"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Point the Quick Shell gallery WinGet install source at the CmdPal-only package so it matches Microsoft Store scope.

- Change WinGet id from `tonythethompson.QuickShell` (CmdPal + Run) to `tonythethompson.QuickShellforCmdPal` (CmdPal only)
- No logo, screenshot, or description changes

## Test plan
- [ ] CI schema validation passes
- [ ] `winget show tonythethompson.QuickShellforCmdPal` resolves
- [ ] Store product ID `9PC8S6LNRT3R` unchanged