### PR TITLE
Add optional `detection.packageFamilyName` to the extension schema

### DIFF
--- a/.github/schemas/extension.schema.json
+++ b/.github/schemas/extension.schema.json
@@ -136,6 +136,15 @@
           }
         ]
       }
+    },
+    "detection": {
+      "type": "object",
+      "description": "Optional hints that let Command Palette recognise an already-installed copy of this extension.",
+      "properties": {
+        "packageFamilyName": { "type": "string", "description": "Package family name of the MSIX package. Lets the gallery show install status for extensions distributed through the Microsoft Store.", "minLength": 1, "examples": ["JiriPolasek.MediaControlsforCommandPalette_h8x1b2c3d4e5f"] }
+      },
+      "required": ["packageFamilyName"],
+      "additionalProperties": false
     }
   }
 }


### PR DESCRIPTION
## Problem

Extensions distributed through the Microsoft Store can never show as **Installed** in the Command Palette gallery, even after the user installs them from the gallery itself.

There are two code paths in CmdPal that set `IsInstalled`, and a Store-only extensions reaches none of them:

1. `ExtensionGalleryViewModel` enumerates installed extensions and matches on `PackageFamilyName`, but the block never gets executed as `PackageFamilyName` is not an allowed field for `extension.json`:

```csharp
foreach (var entry in snapshot)
{
    if (!string.IsNullOrEmpty(entry.PackageFamilyName))
    {
        entry.IsInstalled = installedPfns.Contains(entry.PackageFamilyName);
        entry.IsInstalledStateKnown = true;
    }
}
```
(source: powertoys gh src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs:391)


2. Every other assignment to `IsInstalled` flows from `ApplyWinGetPackageInfo`, which requires a `winget` install source.

At the time of writing, over half of the 82 extensions in the gallery can never display as installed for the user.

## Why this is a schema-only fix

The runtime already supports the field, but schema doesn't allow it:

- `Microsoft.CmdPal.Common/ExtensionGallery/Models/GalleryDetection.cs` defines `PackageFamilyName`.
- `ExtensionGalleryItemViewModel` exposes it via `public string? PackageFamilyName => _entry.Detection?.PackageFamilyName;`
- `doc/extension-gallery.md` documents `detection.packageFamilyName` as a supported optional entry field, and notes it "lets the gallery recognise an already-installed packaged extension before WinGet metadata resolves."

Because `extension.schema.json` sets `additionalProperties: false` and has no `detection` property, the CI rejects the field today. 

## Changes

1. `.github/schemas/extension.schema.json` - added an optional `detection` object with a single required `packageFamilyName` string.
2. `extensions/adamduda/tex-snippets/extension.json` - added the block to my extension to demonstrate.